### PR TITLE
Fix server config typos and port handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ dotenv.config();
 
 const app = express();
 app.use(cors());
-app.use(express.json({ limig: "50mb" }))
+app.use(express.json({ limit: "50mb" }))
 
 app.use("/api/v1/dalle", dalleRoutes);
 
@@ -16,4 +16,5 @@ app.get('/', (req, res) => {
   res.status(200).json({ message: "Hello from DALL.E" })
 })
 
-app.listen(8080, () => console.log('Server has started on port 8080'))
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => console.log(`Server has started on port ${PORT}`))


### PR DESCRIPTION
## Summary
- correct JSON body parser option typo
- allow port override via `process.env.PORT`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404d72269c832f89502fae12f1c975